### PR TITLE
use event-stream@3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "dependencies": {
         "@types/request-promise": "^4.1.42",
         "vscode": "^1.1.6",
+        "event-stream": "3.3.4",
         "gettext-parser": "^2.0.0",
         "babel-plugin-ttag": "^1.4.0",
         "request": "^2.88.0",


### PR DESCRIPTION
The newest vscode version includes:
```
└─┬ vscode@1.1.21
  └─┬ gulp-remote-src-vscode@0.5.0
    └─┬ event-stream@3.3.6
      └── flatmap-stream@0.1.1
```

To avoid having flatmap-stream, use event-stream@3.3.4.