### PR TITLE
refs #32 do not enforce using event-stream@3.3.4 because upstream vsc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,11 +203,11 @@
         "@types/prop-types": "^15.5.6",
         "tslint": "^5.8.0",
         "typescript": "^2.6.1",
-        "vsce": "^1.52.0"
+        "vsce": "^1.52.0",
+        "vscode": "^1.1.22"
     },
     "dependencies": {
         "@types/request-promise": "^4.1.42",
-        "vscode": "^1.1.22",
         "gettext-parser": "^2.0.0",
         "babel-plugin-ttag": "^1.4.0",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -207,8 +207,7 @@
     },
     "dependencies": {
         "@types/request-promise": "^4.1.42",
-        "vscode": "^1.1.6",
-        "event-stream": "3.3.4",
+        "vscode": "^1.1.22",
         "gettext-parser": "^2.0.0",
         "babel-plugin-ttag": "^1.4.0",
         "request": "^2.88.0",


### PR DESCRIPTION
…ode package has been fixed.

This is officially suggested way how to resolve this security issue for vscode extensions.
We are not using event-stream at all so it's not needed to list it in our extension.