### PR TITLE
Code references are now removed from relations when mapper codes are …

### DIFF
--- a/web/components/Field/multiSelect.tsx
+++ b/web/components/Field/multiSelect.tsx
@@ -10,6 +10,7 @@ import { IField } from '.';
 import { IFieldChange } from '../../containers/InterfaceCreator/panel';
 import { TTranslator } from '../../App';
 import withTextContext from '../../hocomponents/withTextContext';
+import withMapperConsumer from '../../hocomponents/withMapperConsumer';
 
 export interface IMultiSelectField {
     get_message: { action: string; object_type: string };
@@ -35,6 +36,7 @@ const MultiSelectField: FunctionComponent<IMultiSelectField & IField & IFieldCha
     simple,
     activeId,
     default_items,
+    removeCodeFromRelations,
 }) => {
     const [items, setItems] = useState<any[]>(default_items || []);
     useMount(() => {
@@ -81,8 +83,14 @@ const MultiSelectField: FunctionComponent<IMultiSelectField & IField & IFieldCha
         setSelectedItems([]);
     };
 
-    const deselectItem: (name: string) => void = name => {
-        setSelectedItems(value.filter((item: any) => item.name !== name));
+    const deselectItem: (tagName: string) => void = tagName => {
+        // If this is the mapper code field
+        // remove the selected mapper code from relations
+        if (name === 'codes') {
+            removeCodeFromRelations([tagName]);
+        }
+        // Remove tag
+        setSelectedItems(value.filter((item: any) => item.name !== tagName));
     };
 
     // Clear button
@@ -133,5 +141,6 @@ const MultiSelectField: FunctionComponent<IMultiSelectField & IField & IFieldCha
 export default compose(
     withTextContext(),
     withMessageHandler(),
+    withMapperConsumer(),
     onlyUpdateForKeys(['value', 'activeId'])
 )(MultiSelectField);

--- a/web/containers/InterfaceCreator/panel.tsx
+++ b/web/containers/InterfaceCreator/panel.tsx
@@ -40,6 +40,7 @@ import isArray from 'lodash/isArray';
 import ClassConnectionsManager, { IClassConnections } from '../ClassConnectionsManager';
 import withMethodsConsumer from '../../hocomponents/withMethodsConsumer';
 import withGlobalOptionsConsumer from '../../hocomponents/withGlobalOptionsConsumer';
+import withMapperConsumer from '../../hocomponents/withMapperConsumer';
 
 export interface IInterfaceCreatorPanel {
     type: string;
@@ -187,6 +188,7 @@ const InterfaceCreatorPanel: FunctionComponent<IInterfaceCreatorPanel> = ({
     showClassConnectionsManager,
     setShowClassConnectionsManager,
     resetClassConnections,
+    removeCodeFromRelations,
 }) => {
     const isInitialMount = useRef(true);
     const [show, setShow] = useState<boolean>(false);
@@ -403,6 +405,11 @@ const InterfaceCreatorPanel: FunctionComponent<IInterfaceCreatorPanel> = ({
     );
 
     const removeField: (fieldName: string, notify?: boolean) => void = (fieldName, notify = true) => {
+        // If mapper code was removed, try to remove relations
+        if (type === 'mapper' && fieldName === 'codes') {
+            // Remove the code from relations
+            removeCodeFromRelations();
+        }
         // Remove the field
         setFields(
             type,
@@ -421,6 +428,9 @@ const InterfaceCreatorPanel: FunctionComponent<IInterfaceCreatorPanel> = ({
                 return map(current, (field: IField) => ({
                     ...field,
                     selected: fieldName === field.name ? false : field.selected,
+                    value: fieldName === field.name ? undefined : field.value,
+                    isValid: fieldName === field.name ? false : field.isValid,
+                    hasValueSet: fieldName === field.name ? false : field.hasValueSet,
                 }));
             },
             activeId
@@ -1053,6 +1063,7 @@ export default compose(
     withFieldsConsumer(),
     withMethodsConsumer(),
     withGlobalOptionsConsumer(),
+    withMapperConsumer(),
     mapProps(
         ({
             type,

--- a/web/hocomponents/withMapper.tsx
+++ b/web/hocomponents/withMapper.tsx
@@ -351,6 +351,42 @@ export default () => (Component: FunctionComponent<any>): FunctionComponent<any>
             });
         };
 
+        const removeCodeFromRelations = (removedMapperCode?: string[]) => {
+            setRelations(current => {
+                const newRelations = reduce(
+                    current,
+                    (newRels, relationData, relationName) => {
+                        const newRelationData = { ...relationData };
+                        // Check if this relation has code
+                        if (newRelationData.code) {
+                            // Get the mapper code without method
+                            const [mapperCodeName] = newRelationData.code.split('.');
+                            // Check if the code matches the removed code
+                            // or if the removed mapper code is empty
+                            // which means all code needs to be removed
+                            if (!removedMapperCode || removedMapperCode.includes(mapperCodeName)) {
+                                // Delete the code
+                                delete newRelationData.code;
+                            }
+                            // Check if there is any other key in the relation
+                            if (size(newRelationData)) {
+                                // Return the new relation
+                                return { ...newRels, [relationName]: newRelationData };
+                            } else {
+                                // Return without this relation
+                                return { ...newRels };
+                            }
+                        }
+                        // Return unchanged
+                        return { ...newRels, [relationName]: relationData };
+                    },
+                    {}
+                );
+
+                return newRelations;
+            });
+        };
+
         return (
             <MapperContext.Provider
                 value={{
@@ -398,6 +434,7 @@ export default () => (Component: FunctionComponent<any>): FunctionComponent<any>
                     setMapper,
                     mapperSubmit,
                     handleMapperSubmitSet,
+                    removeCodeFromRelations,
                 }}
             >
                 <Component {...props} />


### PR DESCRIPTION
…removed.

Steps to test: 

- Create a mapper with a mapper code selected and add this code & one of its methods to a field.
- Remove either the mapper code field or a mapper code tag.
- The `code` relation should be removed from every output field that used this mapper code.

Closes #317 