### PR TITLE
Types such as `list<string>` now properly work in the mapping modal

### DIFF
--- a/web/components/Field/auto.tsx
+++ b/web/components/Field/auto.tsx
@@ -97,7 +97,7 @@ const AutoField: FunctionComponent<IField & IFieldChange> = ({
         handleChange(name, null);
     };
 
-    const renderField = currentType => {
+    const renderField = (currentType: string) => {
         if (!currentType) {
             return null;
         }
@@ -106,6 +106,14 @@ const AutoField: FunctionComponent<IField & IFieldChange> = ({
             // Render a readonly field with null
             return <StringField name={name} value={null} onChange={handleChange} read_only canBeNull />;
         }
+        // Check if there is a `<` in the type
+        const pos: number = currentType.indexOf('<');
+
+        if (pos > 0) {
+            // Get the type from start to the position of the `<`
+            currentType = currentType.slice(0, pos);
+        }
+
         // Render the field based on the type
         switch (currentType) {
             case 'string':

--- a/web/helpers/validations.ts
+++ b/web/helpers/validations.ts
@@ -20,6 +20,14 @@ export const validateField: (type: string, value: any, field?: IField, canBeNull
     if (canBeNull && isNull(value)) {
         return true;
     }
+    // Get the actual type
+    // Check if there is a `<` in the type
+    const pos: number = type.indexOf('<');
+    // If there is a <
+    if (pos > 0) {
+        // Get the type from start to the position of the `<`
+        type = type.slice(0, pos);
+    }
     // Check individual types
     switch (type) {
         case 'binary':


### PR DESCRIPTION
Steps to test

- Create a custom field with mapper with `hash<auto> / list<auto>` / use a provider that has a complex type like that (`list<string>`)
- Try to add a constant to the field, you should get a textarea that supports the main type you selected - (hash or list)

Closes #318 