### PR TITLE
Fixed webview crash when creating a workflow

### DIFF
--- a/web/containers/InterfaceCreator/workflowsView.tsx
+++ b/web/containers/InterfaceCreator/workflowsView.tsx
@@ -122,7 +122,9 @@ const ServicesView: FunctionComponent<IServicesView> = ({
                                                 text={t('Back')}
                                                 icon={'undo'}
                                                 onClick={() => {
-                                                    initialData.changeInitialData('workflow.show_steps', false);
+                                                    if (workflow) {
+                                                        initialData.changeInitialData('workflow.show_steps', false);
+                                                    }
                                                     setShowSteps(false);
                                                 }}
                                             />


### PR DESCRIPTION
Webview no longer crashes if the back button is clicked on step diagram, when creating a workflow.

- Create a workflow, add a step and use the back button - webview should not crash
- Edit a workflow, add a step and use the back button - webview should not crash

Closes #350 