### PR TITLE
Disable changing providers when editing mapper

### DIFF
--- a/web/hocomponents/withMapper.tsx
+++ b/web/hocomponents/withMapper.tsx
@@ -422,7 +422,7 @@ export default () => (Component: FunctionComponent<any>): FunctionComponent<any>
                     outputOptionProvider,
                     setInputOptionProvider,
                     setOutputOptionProvider,
-                    isEditing: props.isEditing,
+                    isEditing: props.isEditing || !!mapper,
                     hideInputSelector,
                     hideOutputSelector,
                     setHideInputSelector,


### PR DESCRIPTION
Providers are no longer editable when editing mapper from the connectors dialog.

- Create a class connection and add a mapper between 2 connectors.
- When you try to edit the mapper from the connectors dialog menu (by clicking on the pencil next to the mapper), you should not be able to edit the providers of the selected mapper, because they are given by the connectors.

Closes #351 