### PR TITLE
Sending is_templated_string to backend

### DIFF
--- a/web/containers/ConfigItemManager/modal.tsx
+++ b/web/containers/ConfigItemManager/modal.tsx
@@ -76,6 +76,7 @@ export default class ConfigItemsModal extends Component {
         templateType: this.props.item?.is_templated_string && this.getTemplateType(this.props.item.value),
         templateKey: this.props.item?.is_templated_string && this.getTemplateKey(this.props.item.value),
         tab: this.props.item?.is_templated_string ? 'template' : 'custom',
+        isTemplatedString: this.props.item?.is_templated_string,
     };
 
     handleObjectChange: Function = (value, type, canBeNull): void => {


### PR DESCRIPTION
`is_templated_string` is now always sent to backend, even if nothing changes.