### PR TITLE
Auto selecting class & connector

### DIFF
--- a/web/containers/ClassConnectionsManager/diagram.tsx
+++ b/web/containers/ClassConnectionsManager/diagram.tsx
@@ -99,6 +99,7 @@ const Connector: React.FC<IConnectorProps> = ({
                     <>
                         {connectors.length > 0 ? (
                             <SelectField
+                                autoSelect
                                 defaultItems={connectors}
                                 predicate={(name: string) => {
                                     // Get the connector
@@ -402,6 +403,7 @@ const ClassConnectionsDiagram: React.FC<IClassConnectionsDiagramProps> = ({
                                         />
                                         <FieldInputWrapper>
                                             <SelectField
+                                                autoSelect
                                                 defaultItems={classes.map(clss => ({
                                                     name: clss.prefix ? `${clss.prefix}:${clss.name}` : clss.name,
                                                 }))}


### PR DESCRIPTION
Class and connectors in the class connections dialog are now automatically selected
if  only 1 item is available

- Create a class with one connector
- Create class connections with the selected class
- Both class and connector should be automatically selected when creating a conneciton

Closes #314 