### PR TITLE
Manage dialog button for workflows

### DIFF
--- a/web/containers/ConfigItemManager/manageButton.tsx
+++ b/web/containers/ConfigItemManager/manageButton.tsx
@@ -13,17 +13,26 @@ export interface IManageConfigButton {
     addMessageListener: TMessageListener;
     disabled: boolean;
     onClick: () => void;
+    type?: string;
 }
 
-const ManageConfigButton: FunctionComponent<IManageConfigButton> = ({ t, addMessageListener, disabled, onClick }) => {
+const ManageConfigButton: FunctionComponent<IManageConfigButton> = ({
+    t,
+    addMessageListener,
+    disabled,
+    onClick,
+    type,
+}) => {
     const [configCount, setConfigCount] = useState<number>(0);
 
     useEffectOnce(() => {
         // Listen for changes in config items for
         // this interface
         const messageHandler = addMessageListener(Messages.RETURN_CONFIG_ITEMS, data => {
+            const itemCount =
+                type === 'workflow' ? size(data.workflow_items?.filter(item => item.is_set)) : size(data.items);
             // Set the new config count
-            setConfigCount(size(data.items));
+            setConfigCount(itemCount);
         });
         // Unregister the message handler
         return () => {

--- a/web/containers/InterfaceCreator/panel.tsx
+++ b/web/containers/InterfaceCreator/panel.tsx
@@ -988,6 +988,7 @@ const InterfaceCreatorPanel: FunctionComponent<IInterfaceCreatorPanel> = ({
                                 )}
                                 {hasConfigManager && (
                                     <ManageConfigButton
+                                        type={type}
                                         disabled={!isConfigManagerEnabled()}
                                         onClick={() => setShowConfigItemsManager(true)}
                                     />

--- a/web/containers/InterfaceCreator/workflowsView.tsx
+++ b/web/containers/InterfaceCreator/workflowsView.tsx
@@ -138,6 +138,7 @@ const ServicesView: FunctionComponent<IServicesView> = ({
                                     <div style={{ float: 'left', width: '48%' }}>
                                         <ButtonGroup fill>
                                             <ManageButton
+                                                type="workflow"
                                                 disabled={!size(steps)}
                                                 onClick={() => setShowConfigItemsManager(true)}
                                             />


### PR DESCRIPTION
The button now shows workflow items that have `is_set` set to true

Closes #359 