### PR TITLE
Check if value_true_type is defined before adding it to yaml

### DIFF
--- a/src/qorus_creator/InterfaceInfo.ts
+++ b/src/qorus_creator/InterfaceInfo.ts
@@ -141,7 +141,11 @@ export class InterfaceInfo {
                 }
 
                 item[templated_key] = is_templated_string;
-                item.value_true_type = value_true_type;
+                //! Only add the key to yaml if the value is defined
+                //! otherwise oload fails!
+                if (value_true_type) {
+                    item.value_true_type = value_true_type;
+                }
             }
         } else {
             let item = this.iface_by_id[iface_id]['config-items'].find(ci_value => ci_value.name === name);
@@ -157,7 +161,11 @@ export class InterfaceInfo {
                 } else {
                     item[level + '-value'] = parseIfComplex(item);
                     item[templated_key] = is_templated_string;
-                    item.value_true_type = value_true_type;
+                    //! Only add the key to yaml if the value is defined
+                    //! otherwise oload fails!
+                    if (value_true_type) {
+                        item.value_true_type = value_true_type;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #556 

I haven't tested because I wasn't able to reproduce but this check ensures that the `value_true_type` is not saved if it's not defined.