### PR TITLE
Replace & disallow spaces in class connections names (#884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.24
+
+#### Bug Fixes
+
+-   Spaces in class connections are no longer allowed & supported
+
 ## 2.3.23
 
 #### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Qorus developer tools for the [Qorus Integration Engine](https://qoretechnologie
 This extension makes it possible to easily create, deploy, and test Qorus interfaces directly from the Visual Studio Code editor.
 It is a perfect tool for creating no-code solutions for the Qorus Integration Engine. The Qorus Developer Tools allow to create building blocks that can be reused later and setup an initial configuration for them.
 
+## Version 2.3.24 overview - What's new:
+
+-   Spaces in class connections are no longer allowed & supported
+
 ## Version 2.3.23 overview - What's new:
 
 -   Passwords for Qorus with special characters are now supported

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "qorus-vscode",
     "displayName": "Qorus Developer Tools",
     "description": "Qorus Integration Engine developer tools",
-    "version": "2.3.23",
+    "version": "2.3.24",
     "publisher": "qoretechnologies",
     "author": {
         "name": "Qore Technologies",

--- a/src/interface_creator/InterfaceCreator.ts
+++ b/src/interface_creator/InterfaceCreator.ts
@@ -235,7 +235,7 @@ export abstract class InterfaceCreator {
         while (contents.match(/\n\n\n/)) {
             contents = contents.replace(/\n\n\n/g, '\n\n');
         }
-        contents.replace(/\n\n$/, '\n');
+        contents.replace(/\n\n$/g, '\n');
         if (contents[contents.length - 1] !== '\n') {
             contents += '\n';
         }

--- a/src/interface_creator/InterfaceWithoutMethodsCreator.ts
+++ b/src/interface_creator/InterfaceWithoutMethodsCreator.ts
@@ -1,4 +1,5 @@
 import * as jsyaml from 'js-yaml';
+import { size } from 'lodash';
 import { t } from 'ttag';
 import { window, workspace } from 'vscode';
 import { qorus_webview } from '../QorusWebview';
@@ -153,7 +154,7 @@ class InterfaceWithoutMethodsCreator extends InterfaceCreator {
                     );
                 }
 
-                if (methods && data['class-connections']) {
+                if (methods && size(data['class-connections'])) {
                     methods += '\n';
                 }
 

--- a/web/containers/ClassConnectionsStateProvider/index.tsx
+++ b/web/containers/ClassConnectionsStateProvider/index.tsx
@@ -30,6 +30,17 @@ const removeMethodTriggers = (methods, connectionData) =>
         return [...newData, newConnector];
     }, []);
 
+const transformClassConnections = (connections: IClassConnections): IClassConnections => {
+    return reduce(
+        connections,
+        (newConnections, data, name) => ({
+            ...newConnections,
+            [name.replace(/ /g, '')]: data,
+        }),
+        {}
+    );
+};
+
 const ClassConnectionsStateProvider = ({
     selectedFields,
     type,
@@ -39,7 +50,7 @@ const ClassConnectionsStateProvider = ({
 }) => {
     const [showClassConnectionsManager, setShowClassConnectionsManager] = useState<boolean>(false);
     const [classConnectionsData, setClassConnectionsData] = useState<IClassConnections>(
-        initialData[type]?.['class-connections']
+        transformClassConnections(initialData[type]?.['class-connections'])
     );
     const [methodsCount, setMethodsCount] = useState<number>(null);
 


### PR DESCRIPTION
* Replace & disallow spaces in class connections names

* Do not add empty line if the class connections object exists but is empty, do not allow prohibited chars in the Connection name
